### PR TITLE
Windows native build support

### DIFF
--- a/dggal-sys/build.rs
+++ b/dggal-sys/build.rs
@@ -36,6 +36,61 @@ pub fn bsd_make() -> Command {
     Command::new("make")
 }
 
+fn obj_lib_subdir() -> String {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string());
+    let platform = match target_os.as_str() {
+        "windows" => "win32",
+        "macos" => "apple",
+        _ => "linux",
+    };
+    // On 32-bit Windows, crossplatform.mk sets ARCH=x32 → COMPILER_SUFFIX=.x32
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let arch_suffix = if target_os == "windows" && target_arch == "x86" {
+        ".x32"
+    } else {
+        ""
+    };
+    format!("obj/{}{}/lib", platform, arch_suffix)
+}
+
+fn platform_name() -> &'static str {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string());
+    match target_os.as_str() {
+        "windows" => "win32",
+        "macos" => "apple",
+        _ => "linux",
+    }
+}
+
+fn find_sh_dir() -> Option<PathBuf> {
+    if let Ok(out) = Command::new("where.exe").arg("sh.exe").output() {
+        if out.status.success() {
+            let s = String::from_utf8_lossy(&out.stdout);
+            if let Some(line) = s.lines().next() {
+                return PathBuf::from(line.trim()).parent().map(|p| p.to_path_buf());
+            }
+        }
+    }
+    let out = Command::new("where.exe").arg("git.exe").output().ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    let git = PathBuf::from(s.lines().next()?.trim());
+    let root = git.parent()?.parent()?;
+    let usr_bin = root.join("usr").join("bin");
+    if usr_bin.join("sh.exe").exists() { return Some(usr_bin); }
+    let bin = root.join("bin");
+    if bin.join("sh.exe").exists() { return Some(bin); }
+    None
+}
+
+fn apply_shell(cmd: &mut Command) {
+    if let Some(sh_dir) = find_sh_dir() {
+        let existing = env::var("PATH").unwrap_or_default();
+        let new_path = format!("{};{}", sh_dir.display(), existing);
+        cmd.env("PATH", new_path);
+        cmd.env("SHELL", "sh");
+    }
+}
+
 fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let dggal_dir = manifest_dir
@@ -46,23 +101,16 @@ fn main() {
     let bindings_dir = dggal_dir.join("bindings/c");
     let lib_dir = manifest_dir.join("lib");
 
-    // Step 0: clean ecere/eC/
-    let status = make()
-        .current_dir(&dggal_dir)
-        .arg("distclean")
-        .status()
-        .expect(&format!(
-            "Failed to run `make distclean` in {:?}",
-            &dggal_dir
-        ));
-    if !status.success() {
-        panic!("{}", &format!("make distclean in {:?} failed", &dggal_dir));
-    }
-
     // Step 1: Build dggal core in ecere/dggal/
-    let dggal_dir_output = make()
+    let mut dggal_make = make();
+    dggal_make
+        .arg("-B")
         .current_dir(&dggal_dir)
-        .env_remove("DEBUG")
+        .env("PLATFORM", platform_name())
+        .env("MSYSCON", "1")
+        .env_remove("DEBUG");
+    apply_shell(&mut dggal_make);
+    let dggal_dir_output = dggal_make
         .output()
         .expect(&format!("Failed to run make in {:?}", dggal_dir));
 
@@ -81,16 +129,21 @@ fn main() {
 
     let bindings_dir_obj = &bindings_dir.join("obj");
     if bindings_dir_obj.exists() {
-        println!("cargo:warning=Cleaning {:?}", bindings_dir_obj); // optional debug
+        println!("cargo:warning=Cleaning {:?}", bindings_dir_obj);
         if let Err(err) = fs::remove_dir_all(&bindings_dir_obj) {
             panic!("Failed to delete {:?}: {}", bindings_dir_obj, err);
         }
     }
 
     // Step 2: Build Rust bindings via Makefile
-    let bindings_dir_output = make()
+    let mut bindings_make = make();
+    bindings_make
         .current_dir(&bindings_dir)
-        .env_remove("DEBUG")
+        .env("PLATFORM", platform_name())
+        .env("MSYSCON", "1")
+        .env_remove("DEBUG");
+    apply_shell(&mut bindings_make);
+    let bindings_dir_output = bindings_make
         .output()
         .expect("Failed to run make");
 
@@ -113,12 +166,15 @@ fn main() {
     fs::create_dir_all(&lib_dir).expect(&format!("Failed to create {:?} directory", &lib_dir));
 
     let files_to_copy = ["libdggal_cStatic.a", "libdggalStatic.a"];
+    let obj_subdir = obj_lib_subdir();
 
     for file_name in &files_to_copy {
-        let src = dggal_dir.join("obj/linux/lib").join(file_name);
+        let src = dggal_dir.join(&obj_subdir).join(file_name);
         let dst = lib_dir.join(file_name);
 
-        fs::copy(&src, &dst).expect(&format!("Failed to copy {}", file_name));
+        fs::copy(&src, &dst).unwrap_or_else(|e| {
+            panic!("Failed to copy {} from {:?}: {}", file_name, src, e)
+        });
     }
 
     println!("cargo:rustc-link-search=native={}", lib_dir.display());

--- a/dggal-sys/src/lib.rs
+++ b/dggal-sys/src/lib.rs
@@ -1,1 +1,1 @@
-../../ecere/dggal/bindings/rust/dggal_cffi.rs
+include!("../../ecere/dggal/bindings/rust/dggal_cffi.rs");

--- a/ecrt-sys/build.rs
+++ b/ecrt-sys/build.rs
@@ -36,6 +36,55 @@ pub fn bsd_make() -> Command {
     Command::new("make")
 }
 
+fn obj_subdir(subdir: &str) -> String {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string());
+    let platform = match target_os.as_str() {
+        "windows" => "win32",
+        "macos" => "apple",
+        _ => "linux",
+    };
+    // On 32-bit Windows, crossplatform.mk sets ARCH=x32 → COMPILER_SUFFIX=.x32
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let arch_suffix = if target_os == "windows" && target_arch == "x86" {
+        ".x32"
+    } else {
+        ""
+    };
+    format!("obj/{}{}/{}", platform, arch_suffix, subdir)
+}
+
+fn obj_lib_subdir() -> String { obj_subdir("lib") }
+fn obj_bin_subdir() -> String { obj_subdir("bin") }
+
+fn find_sh_dir() -> Option<PathBuf> {
+    if let Ok(out) = Command::new("where.exe").arg("sh.exe").output() {
+        if out.status.success() {
+            let s = String::from_utf8_lossy(&out.stdout);
+            if let Some(line) = s.lines().next() {
+                return PathBuf::from(line.trim()).parent().map(|p| p.to_path_buf());
+            }
+        }
+    }
+    let out = Command::new("where.exe").arg("git.exe").output().ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    let git = PathBuf::from(s.lines().next()?.trim());
+    let root = git.parent()?.parent()?;
+    let usr_bin = root.join("usr").join("bin");
+    if usr_bin.join("sh.exe").exists() { return Some(usr_bin); }
+    let bin = root.join("bin");
+    if bin.join("sh.exe").exists() { return Some(bin); }
+    None
+}
+
+fn apply_shell(cmd: &mut Command) {
+    if let Some(sh_dir) = find_sh_dir() {
+        let existing = env::var("PATH").unwrap_or_default();
+        let new_path = format!("{};{}", sh_dir.display(), existing);
+        cmd.env("PATH", new_path);
+        cmd.env("SHELL", "sh");
+    }
+}
+
 fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let ec_dir = manifest_dir
@@ -46,20 +95,18 @@ fn main() {
     let bindings_dir = ec_dir.join("bindings/c");
     let lib_dir = manifest_dir.join("lib");
 
-    // Step 0: clean ecere/eC/
-    let status = make()
-        .current_dir(&ec_dir)
-        .arg("distclean")
-        .status()
-        .expect(&format!("Failed to run `make distclean` in {:?}", &ec_dir));
-    if !status.success() {
-        panic!("{}", &format!("make distclean in {:?} failed", &ec_dir));
-    }
+    let bin_out_dir = ec_dir.join(obj_bin_subdir());
 
     // Step 1: Build eC core in ecere/eC/
-    let ec_dir_output = make()
+    let mut ec_make = make();
+    ec_make
+        .arg("-B")
         .current_dir(&ec_dir)
-        .env_remove("DEBUG")
+        .env("PLATFORM", platform_name())
+        .env("MSYSCON", "1")
+        .env_remove("DEBUG");
+    apply_shell(&mut ec_make);
+    let ec_dir_output = ec_make
         .output()
         .expect(&format!("Failed to run make in {:?}", ec_dir));
 
@@ -76,18 +123,51 @@ fn main() {
         panic!("make in {:?} failed", ec_dir);
     }
 
+    // Post-build: ensure eC compiler tools are in obj/<platform>/bin/.
+    // The 2nd-stage tools (ecp/obj/release.*) link against ecrt.dll and can
+    // crash with access violations on some Windows setups.  Prefer the
+    // bootstrap tools (bootstrap/obj/bin.*) which are pure-C self-contained.
+    let exe = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    for tool in &["ecp", "ecc", "ecs"] {
+        let tool_file = format!("{}{}", tool, exe);
+        let dst = bin_out_dir.join(&tool_file);
+        if !dst.exists() {
+            let bootstrap_src = ec_dir
+                .join("bootstrap")
+                .join("obj")
+                .join(format!("bin.{}", platform_name()))
+                .join(&tool_file);
+            let release_src = ec_dir
+                .join(tool)
+                .join("obj")
+                .join(format!("release.{}", platform_name()))
+                .join(&tool_file);
+            let src = if bootstrap_src.exists() { bootstrap_src } else { release_src };
+            if src.exists() {
+                fs::copy(&src, &dst).unwrap_or_else(|e| {
+                    panic!("Failed to copy {} from {:?}: {}", tool_file, src, e)
+                });
+            }
+        }
+    }
+
     let bindings_dir_obj = &bindings_dir.join("obj");
     if bindings_dir_obj.exists() {
-        println!("cargo:warning=Cleaning {:?}", bindings_dir_obj); // optional debug
+        println!("cargo:warning=Cleaning {:?}", bindings_dir_obj);
         if let Err(err) = fs::remove_dir_all(&bindings_dir_obj) {
             panic!("Failed to delete {:?}: {}", bindings_dir_obj, err);
         }
     }
 
     // Step 2: Build Rust bindings via Makefile.ecrt-sys
-    let bindings_dir_output = make()
+    let mut bindings_make = make();
+    bindings_make
         .current_dir(&bindings_dir)
-        .env_remove("DEBUG")
+        .env("PLATFORM", platform_name())
+        .env("MSYSCON", "1")
+        .env_remove("DEBUG");
+    apply_shell(&mut bindings_make);
+    let bindings_dir_output = bindings_make
         .output()
         .expect(&format!("Failed to run `make` in {:?}", bindings_dir));
 
@@ -110,18 +190,30 @@ fn main() {
     fs::create_dir_all(&lib_dir).expect(&format!("Failed to create {:?} directory", &lib_dir));
 
     let files_to_copy = ["libecrt_cStatic.a", "libecrtStatic.a"];
+    let obj_subdir = obj_lib_subdir();
 
     for file_name in &files_to_copy {
-        let src = ec_dir.join("obj/linux/lib").join(file_name);
+        let src = ec_dir.join(&obj_subdir).join(file_name);
         let dst = lib_dir.join(file_name);
 
-        fs::copy(&src, &dst).expect(&format!("Failed to copy {}", file_name));
+        fs::copy(&src, &dst).unwrap_or_else(|e| {
+            panic!("Failed to copy {} from {:?}: {}", file_name, src, e)
+        });
     }
 
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     println!("cargo:rustc-link-lib=static=ecrt_cStatic");
     println!("cargo:rustc-link-lib=static=ecrtStatic");
 
-    // zlib (install via sudo apt install zlib1g-dev)
+    // zlib: on Linux install zlib1g-dev; on Windows TDM-GCC ships libz.a
     println!("cargo:rustc-link-lib=z");
+}
+
+fn platform_name() -> &'static str {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string());
+    match target_os.as_str() {
+        "windows" => "win32",
+        "macos" => "apple",
+        _ => "linux",
+    }
 }

--- a/ecrt-sys/build.rs
+++ b/ecrt-sys/build.rs
@@ -54,7 +54,6 @@ fn obj_subdir(subdir: &str) -> String {
 }
 
 fn obj_lib_subdir() -> String { obj_subdir("lib") }
-fn obj_bin_subdir() -> String { obj_subdir("bin") }
 
 fn find_sh_dir() -> Option<PathBuf> {
     if let Ok(out) = Command::new("where.exe").arg("sh.exe").output() {
@@ -95,8 +94,6 @@ fn main() {
     let bindings_dir = ec_dir.join("bindings/c");
     let lib_dir = manifest_dir.join("lib");
 
-    let bin_out_dir = ec_dir.join(obj_bin_subdir());
-
     // Step 1: Build eC core in ecere/eC/
     let mut ec_make = make();
     ec_make
@@ -121,34 +118,6 @@ fn main() {
 
     if !ec_dir_output.status.success() {
         panic!("make in {:?} failed", ec_dir);
-    }
-
-    // Post-build: ensure eC compiler tools are in obj/<platform>/bin/.
-    // The 2nd-stage tools (ecp/obj/release.*) link against ecrt.dll and can
-    // crash with access violations on some Windows setups.  Prefer the
-    // bootstrap tools (bootstrap/obj/bin.*) which are pure-C self-contained.
-    let exe = if cfg!(target_os = "windows") { ".exe" } else { "" };
-    for tool in &["ecp", "ecc", "ecs"] {
-        let tool_file = format!("{}{}", tool, exe);
-        let dst = bin_out_dir.join(&tool_file);
-        if !dst.exists() {
-            let bootstrap_src = ec_dir
-                .join("bootstrap")
-                .join("obj")
-                .join(format!("bin.{}", platform_name()))
-                .join(&tool_file);
-            let release_src = ec_dir
-                .join(tool)
-                .join("obj")
-                .join(format!("release.{}", platform_name()))
-                .join(&tool_file);
-            let src = if bootstrap_src.exists() { bootstrap_src } else { release_src };
-            if src.exists() {
-                fs::copy(&src, &dst).unwrap_or_else(|e| {
-                    panic!("Failed to copy {} from {:?}: {}", tool_file, src, e)
-                });
-            }
-        }
     }
 
     let bindings_dir_obj = &bindings_dir.join("obj");

--- a/ecrt-sys/src/lib.rs
+++ b/ecrt-sys/src/lib.rs
@@ -1,1 +1,1 @@
-../../ecere/eC/bindings/rust/ecrt_cffi.rs
+include!("../../ecere/eC/bindings/rust/ecrt_cffi.rs");

--- a/ecrt/src/lib.rs
+++ b/ecrt/src/lib.rs
@@ -1,1 +1,3 @@
-../../ecere/eC/bindings/rust/ecrt.rs
+#[path = "../../ecere/eC/bindings/rust/ecrt.rs"]
+mod ecrt_inner;
+pub use ecrt_inner::*;


### PR DESCRIPTION
Fixes cargo build on Windows with TDM-GCC (or any MinGW toolchain). Previously the build failed immediately because make distclean ran POSIX shell commands through cmd.exe, which has no cp, rm, or mkdir -p.

## Changes

### Fixed broken symlinks in src/lib.rs files

On Windows with core.symlinks=false, git stores symlinks as plain text files containing the target path. The three src/lib.rs files were text files instead of real symlinks, causing compile errors.

- ecrt-sys/src/lib.rs, dggal-sys/src/lib.rs: replaced the path-text content with include!("...")
- ecrt/src/lib.rs: cannot use include!() because the included file (ecrt.rs) opens with #![allow(...)] inner attributes, which cause a parse error when expanded inline. Used #[path = "..."] mod ecrt_inner; pub use ecrt_inner::*; instead — inner attributes are valid at the start of a module body.

### ecrt-sys/build.rs and dggal-sys/build.rs

- Removed make distclean — replaced with make -B (always-make), which forces a full rebuild unconditionally without needing to run POSIX clean commands. Equivalent behaviour, no manual directory management required.
- Added PLATFORM=<win32|linux|apple> and MSYSCON=1 environment variables. MSYSCON=1 tells crossplatform.mk to generate POSIX-style recipes instead of cmd.exe-style ones.
- Added find_sh_dir() + apply_shell(): on Windows, GNU make needs SHELL=sh and POSIX tools (cp, mkdir) on PATH to execute those recipes. The function locates sh.exe — checking PATH first (works with MSYS2, Cygwin, or any setup where sh is already available), then falling back to deriving the path from git.exe location (Git for Windows ships sh.exe and POSIX tools in usr/bin/).
- Fixed hardcoded obj/linux/lib path for copying .a files — replaced with a platform-aware obj_lib_subdir() helper.

### Linux / macOS

No behaviour change. MSYSCON=1 is ignored on non-Windows hosts, apply_shell is a no-op when where.exe is absent, and make -B produces the same result as distclean + make.

_Disclaimer: this PR was partially made with the help of Claude Code. My understanding of build systems is quite limited._

